### PR TITLE
add rulesets

### DIFF
--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,4 +1,11 @@
+// Names based roughly on:
+// https://html.spec.whatwg.org/multipage/parsing.html
+
 package routes
+
+import (
+	"unicode"
+)
 
 type StepKind int
 
@@ -32,3 +39,217 @@ const (
 	AltTextCloseSequence
 	CommentText
 )
+
+func Route(glyph rune, prevKind StepKind) StepKind {
+	switch prevKind {
+	case Attr:
+		return getKindFromAttribute(glyph)
+	case AttrMapInjection:
+		return getKindFromInjection(glyph)
+	case AttrQuote:
+		return getKindFromAttributeQuote(glyph)
+	case AttrQuoteClosed:
+		return getKindFromAttributeQuoteClosed(glyph)
+	case AttrSetter:
+		return getKindFromAttributeSetter(glyph)
+	case AttrValue:
+		return getKindFromAttributeQuote(glyph)
+	case AttrValueUnquoted:
+		return getKindFromAttributeValueUnquoted(glyph)
+	case DescendantInjection:
+		return getKindFromInjection(glyph)
+	case Element:
+		return getKindFromElement(glyph)
+	case ElementSpace:
+		return getKindFromElementSpace(glyph)
+	case EmptyElement:
+		return getKindFromEmptyElement(glyph)
+	case InjectionSpace:
+		return getKindFromInjection(glyph)
+	case Tag:
+		return getKindFromTag(glyph)
+	case TailElementSolidus:
+		return getKindFromTailElementSolidus(glyph)
+	case TailElementSpace:
+		return getKindFromTailElementSpace(glyph)
+	case TailTag:
+		return getKindFromTailTag(glyph)
+	default:
+		return getKindFromInitial(glyph)
+	}
+}
+
+func getKindFromAttribute(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return ElementSpace
+	}
+	switch glyph {
+	case '=':
+		return AttrSetter
+	case '>':
+		return ElementClosed
+	case '/':
+		return EmptyElement
+	case '{':
+		return AttrMapInjection
+	default:
+		return Attr
+	}
+}
+
+func getKindFromInjection(glyph rune) StepKind {
+	switch glyph {
+	case '}':
+		return InjectionConfirmed
+	default:
+		return InjectionSpace
+	}
+}
+
+func getKindFromAttributeQuote(glyph rune) StepKind {
+	switch glyph {
+	case '"':
+		return AttrQuoteClosed
+	default:
+		return AttrValue
+	}
+}
+
+func getKindFromAttributeQuoteClosed(glyph rune) StepKind {
+	switch glyph {
+	case '>':
+		return ElementClosed
+	case '/':
+		return EmptyElement
+	default:
+		return ElementSpace
+	}
+}
+
+func getKindFromAttributeSetter(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return AttrSetter
+	}
+
+	switch glyph {
+	case '"':
+		return AttrQuote
+	default:
+		return AttrValueUnquoted
+	}
+}
+
+func getKindFromAttributeValueUnquoted(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return ElementSpace
+	}
+
+	switch glyph {
+	case '>':
+		return ElementClosed
+	default:
+		return AttrValueUnquoted
+	}
+}
+
+func getKindFromElement(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return Element
+	}
+
+	switch glyph {
+	case '>':
+		return Fragment
+	case '/':
+		return TailElementSolidus
+	default:
+		return Tag
+	}
+}
+
+func getKindFromElementSpace(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return ElementSpace
+	}
+
+	switch glyph {
+	case '>':
+		return ElementClosed
+	case '/':
+		return EmptyElement
+	case '{':
+		return AttrMapInjection
+	default:
+		return Attr
+	}
+}
+
+func getKindFromEmptyElement(glyph rune) StepKind {
+	switch glyph {
+	case '>':
+		return EmptyElementClosed
+	default:
+		return EmptyElement
+	}
+}
+
+func getKindFromTag(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return ElementSpace
+	}
+
+	switch glyph {
+	case '>':
+		return ElementClosed
+	case '/':
+		return EmptyElement
+	default:
+		return Tag
+	}
+}
+
+func getKindFromTailElementSolidus(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return TailElementSolidus
+	}
+
+	switch glyph {
+	case '>':
+		return FragmentClosed
+	default:
+		return TailTag
+	}
+}
+
+func getKindFromTailTag(glyph rune) StepKind {
+	if unicode.IsSpace(glyph) {
+		return TailElementSpace
+	}
+
+	switch glyph {
+	case '>':
+		return TailElementClosed
+	default:
+		return TailTag
+	}
+}
+
+func getKindFromTailElementSpace(glyph rune) StepKind {
+	switch glyph {
+	case '>':
+		return TailElementClosed
+	default:
+		return TailElementSpace
+	}
+}
+
+func getKindFromInitial(glyph rune) StepKind {
+	switch glyph {
+	case '<':
+		return Element
+	case '{':
+		return DescendantInjection
+	default:
+		return Text
+	}
+}

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -4,7 +4,7 @@ type RulesetInterface interface {
 	GetInitialNamespace() string
 	TagIsComment(string) bool
 	GetCloseSequenceFromAltTextTag(string) string
-	GetTagFromCloseSequence(string) string
+	GetAltTextTagFromCloseSequence(string) string
 	RespectIndentation(string) bool
 	TagIsBannedEl(string) bool
 	TagIsVoidEl(string) bool
@@ -13,6 +13,7 @@ type RulesetInterface interface {
 	TagIsInlineEl(string) bool
 }
 
+// Html for server side
 type ServerRules struct{}
 
 func (s ServerRules) GetInitialNamespace() string {
@@ -23,6 +24,41 @@ func (s ServerRules) TagIsComment(tag string) bool {
 	return "!--" == tag
 }
 
+func (s ServerRules) GetCloseSequenceFromAltTextTag(tag string) string {
+	return getCloseSequenceFromAltTextTag(tag)
+}
+
+func (s ServerRules) GetAltTextTagFromCloseSequence(tag string) string {
+	return getAltTagFromCloseSequence(tag)
+}
+
+func (s ServerRules) RespectIndentation(tag string) bool {
+	return true
+}
+
+func (s ServerRules) TagIsBannedEl(tag string) bool {
+	return isBannedEl(tag)
+}
+
+func (s ServerRules) TagIsVoidEl(tag string) bool {
+	return isVoidEl(tag)
+}
+
+func (s ServerRules) TagIsNamespaceEl(tag string) bool {
+	return isNamespaceEl(tag)
+}
+
+func (s ServerRules) TagIsPreservedTextEl(tag string) bool {
+	return isPreservedTextEl(tag)
+}
+
+func (s ServerRules) TagIsInlineEl(tag string) bool {
+	return isInlineEl(tag)
+}
+
+// Html for client side
+//
+//	(no elements that can directly manipulate dom)
 type ClientRules struct{}
 
 func (c ClientRules) GetInitialNamespace() string {
@@ -33,6 +69,54 @@ func (s ClientRules) TagIsComment(tag string) bool {
 	return "!--" == tag
 }
 
+func (s ClientRules) GetCloseSequenceFromAltTextTag(tag string) string {
+	return getCloseSequenceFromAltTextTag(tag)
+}
+
+func (s ClientRules) GetAltTextTagFromCloseSequence(tag string) string {
+	return getAltTagFromCloseSequence(tag)
+}
+
+func (s ClientRules) RespectIndentation(tag string) bool {
+	return false
+}
+
+func (s ClientRules) TagIsBannedEl(tag string) bool {
+	switch tag {
+	case "!--":
+		return true
+	case "link":
+		return true
+	case "script":
+		return true
+	case "style":
+		return true
+	default:
+		return isBannedEl(tag)
+	}
+}
+
+func (s ClientRules) TagIsVoidEl(tag string) bool {
+	return isVoidEl(tag)
+}
+
+func (s ClientRules) TagIsNamespaceEl(tag string) bool {
+	return isNamespaceEl(tag)
+}
+
+func (s ClientRules) TagIsPreservedTextEl(tag string) bool {
+	return isPreservedTextEl(tag)
+}
+
+func (s ClientRules) TagIsInlineEl(tag string) bool {
+	if "a" == tag {
+		return true
+	}
+
+	return isInlineEl(tag)
+}
+
+// Xml
 type XmlRules struct{}
 
 func (x XmlRules) GetInitialNamespace() string {
@@ -54,7 +138,7 @@ func (s XmlRules) GetCloseSequenceFromTag(tag string) string {
 	}
 }
 
-func (s XmlRules) GetTagFromCloseSequence(tag string) string {
+func (s XmlRules) GetAltTextTagFromCloseSequence(tag string) string {
 	switch tag {
 	case "-->":
 		return "!--"
@@ -87,6 +171,33 @@ func (s XmlRules) TagIsPreservedTextEl(tag string) bool {
 
 func (s XmlRules) TagIsInlineEl(tag string) bool {
 	return false
+}
+
+// Utils
+func getCloseSequenceFromAltTextTag(tag string) string {
+	switch tag {
+	case "!--":
+		return "-->"
+	case "script":
+		return "</script>"
+	case "style":
+		return "</style>"
+	default:
+		return ""
+	}
+}
+
+func getAltTagFromCloseSequence(tag string) string {
+	switch tag {
+	case "-->":
+		return "!--"
+	case "</script>":
+		return "script"
+	case "</style>":
+		return "style"
+	default:
+		return ""
+	}
 }
 
 func isBannedEl(tag string) bool {

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -1,4 +1,4 @@
-package rulesets3
+package rulesets
 
 type RulesetInterface interface {
 	GetInitialNamespace() string
@@ -11,4 +11,272 @@ type RulesetInterface interface {
 	TagIsNamespaceEl(string) bool
 	TagIsPreservedTextEl(string) bool
 	TagIsInlineEl(string) bool
+}
+
+type ServerRules struct{}
+
+func (s ServerRules) GetInitialNamespace() string {
+	return "html"
+}
+
+func (s ServerRules) TagIsComment(tag string) bool {
+	return "!--" == tag
+}
+
+type ClientRules struct{}
+
+func (c ClientRules) GetInitialNamespace() string {
+	return "html"
+}
+
+func (s ClientRules) TagIsComment(tag string) bool {
+	return "!--" == tag
+}
+
+type XmlRules struct{}
+
+func (x XmlRules) GetInitialNamespace() string {
+	return "xml"
+}
+
+func (s XmlRules) TagIsComment(tag string) bool {
+	return "!--" == tag
+}
+
+func (s XmlRules) GetCloseSequenceFromTag(tag string) string {
+	switch tag {
+	case "!--":
+		return "-->"
+	case "!CDATA[[":
+		return "]]>"
+	default:
+		return ""
+	}
+}
+
+func (s XmlRules) GetTagFromCloseSequence(tag string) string {
+	switch tag {
+	case "-->":
+		return "!--"
+	case "]]>":
+		return "!CDATA[["
+	default:
+		return ""
+	}
+}
+
+func (s XmlRules) RespectIndentation(tag string) bool {
+	return true
+}
+
+func (s XmlRules) TagIsBannedEl(tag string) bool {
+	return false
+}
+
+func (s XmlRules) TagIsVoidEl(tag string) bool {
+	return false
+}
+
+func (s XmlRules) TagIsNamespaceEl(tag string) bool {
+	return false
+}
+
+func (s XmlRules) TagIsPreservedTextEl(tag string) bool {
+	return false
+}
+
+func (s XmlRules) TagIsInlineEl(tag string) bool {
+	return false
+}
+
+func isBannedEl(tag string) bool {
+	switch tag {
+	case "acronym":
+		return true
+	case "big":
+		return true
+	case "center":
+		return true
+	case "content":
+		return true
+	case "dir":
+		return true
+	case "font":
+		return true
+	case "frame":
+		return true
+	case "framset":
+		return true
+	case "image":
+		return true
+	case "marquee":
+		return true
+	case "menuitem":
+		return true
+	case "nobr":
+		return true
+	case "noembed":
+		return true
+	case "noframes":
+		return true
+	case "param":
+		return true
+	case "plaintext":
+		return true
+	case "rb":
+		return true
+	case "rtc":
+		return true
+	case "shadow":
+		return true
+	case "strike":
+		return true
+	case "tt":
+		return true
+	case "xmp":
+		return true
+	default:
+		return false
+	}
+}
+
+func isVoidEl(tag string) bool {
+	switch tag {
+	case "!--":
+		return true
+	case "!DOCTYPE":
+		return true
+	case "area":
+		return true
+	case "base":
+		return true
+	case "br":
+		return true
+	case "col":
+		return true
+	case "embed":
+		return true
+	case "hr":
+		return true
+	case "img":
+		return true
+	case "input":
+		return true
+	case "link":
+		return true
+	case "meta":
+		return true
+	case "param":
+		return true
+	case "source":
+		return true
+	case "track":
+		return true
+	case "wbr":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNamespaceEl(tag string) bool {
+	switch tag {
+	case "html":
+		return true
+	case "math":
+		return true
+	case "svg":
+		return true
+	default:
+		return false
+	}
+}
+
+func isPreservedTextEl(tag string) bool {
+	return "pre" == tag
+}
+
+func isInlineEl(tag string) bool {
+	switch tag {
+	case "abbr":
+		return true
+	case "area":
+		return true
+	case "audio":
+		return true
+	case "b":
+		return true
+	case "bdi":
+		return true
+	case "bdo":
+		return true
+	case "cite":
+		return true
+	case "code":
+		return true
+	case "data":
+		return true
+	case "dfn":
+		return true
+	case "em":
+		return true
+	case "embed":
+		return true
+	case "i":
+		return true
+	case "iframe":
+		return true
+	case "img":
+		return true
+	case "kbd":
+		return true
+	case "map":
+		return true
+	case "mark":
+		return true
+	case "object":
+		return true
+	case "picture":
+		return true
+	case "portal":
+		return true
+	case "q":
+		return true
+	case "rp":
+		return true
+	case "rt":
+		return true
+	case "ruby":
+		return true
+	case "s":
+		return true
+	case "samp":
+		return true
+	case "small":
+		return true
+	case "source":
+		return true
+	case "span":
+		return true
+	case "strong":
+		return true
+	case "sub":
+		return true
+	case "sup":
+		return true
+	case "time":
+		return true
+	case "track":
+		return true
+	case "u":
+		return true
+	case "var":
+		return true
+	case "video":
+		return true
+	case "wbr":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Html is unique from other xml like languages because of [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)

Rulesets inform coyote how to build and compose html documents (and xml docs).

This PR creates rulesets for:
- static html templates (ServerRules)
- html meant for clients like htmx (ClientRules)
- xml
